### PR TITLE
Update for release Stash@v2020.6.26

### DIFF
--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,17 +28,17 @@
       "show": true
     },
     {
-      "version": "9.6",
+      "version": "11.2-v1",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "10.2",
+      "version": "11.2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "10.6",
+      "version": "11.1-v1",
       "hostDocs": true,
       "show": true
     },
@@ -48,10 +48,35 @@
       "show": true
     },
     {
-      "version": "11.2",
+      "version": "10.6-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "10.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "10.2-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "10.2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "9.6-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "9.6",
       "hostDocs": true,
       "show": true
     }
   ],
-  "latestVersion": "11.2"
+  "latestVersion": "11.2-v1"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -289,6 +289,14 @@
       "show": true
     },
     {
+      "version": "v2020.6.26",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.6.26"
+      }
+    },
+    {
       "version": "v0.9.0-rc.6",
       "hostDocs": true,
       "show": true,
@@ -409,7 +417,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.9.0-rc.6",
+  "latestVersion": "v2020.6.26",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -565,6 +573,46 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.6.26"
+          ],
+          "subProjectVersions": [
+            "11.1-v1"
+          ]
+        },
+        {
+          "versions": [
+            "v2020.6.26"
+          ],
+          "subProjectVersions": [
+            "10.6-v1"
+          ]
+        },
+        {
+          "versions": [
+            "v2020.6.26"
+          ],
+          "subProjectVersions": [
+            "10.2-v1"
+          ]
+        },
+        {
+          "versions": [
+            "v2020.6.26"
+          ],
+          "subProjectVersions": [
+            "9.6-v1"
+          ]
+        },
+        {
+          "versions": [
+            "v2020.6.26"
+          ],
+          "subProjectVersions": [
+            "11.2-v1"
+          ]
+        },
         {
           "versions": [
             "v0.9.0-rc.1",


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.6.26
Release-tracker: https://github.com/appscodelabs/release-automaton-demo/pull/6